### PR TITLE
Added option to delete episode upon completion of playback.

### DIFF
--- a/res/xml/preferences.xml
+++ b/res/xml/preferences.xml
@@ -23,6 +23,12 @@
             android:key="prefFollowQueue"
             android:summary="@string/pref_followQueue_sum"
             android:title="@string/pref_followQueue_title"/>
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="prefAutoDelete"
+            android:summary="Delete epidsode when playback completes"
+            android:title="Delete On Finish"/>
         <Preference
             android:key="prefPlaybackSpeedLauncher"
             android:summary="@string/pref_playback_speed_sum"

--- a/src/de/danoeh/antennapod/service/playback/PlaybackService.java
+++ b/src/de/danoeh/antennapod/service/playback/PlaybackService.java
@@ -523,6 +523,15 @@ public class PlaybackService extends Service {
             if (isAutoFlattrable(media) && UserPreferences.getAutoFlattrPlayedDurationThreshold() == 1.0f) {
                 DBTasks.flattrItemIfLoggedIn(PlaybackService.this, item);
             }
+
+            //Delete episode if enabled
+            if(UserPreferences.isAutoDelete()) {
+                DBWriter.deleteFeedMediaOfItem(PlaybackService.this, item.getMedia().getId());
+
+                if(BuildConfig.DEBUG)
+                    Log.d(TAG, "Episode Deleted");
+            }
+
         }
 
         // Load next episode if previous episode was in the queue and if there


### PR DESCRIPTION
Working from issue #92 this small patch adds an checkbox in the preference screen to automatically delete an episode after playback is complete.

This makes use of the existing variable PREF_AUTO_DELETE