### PR TITLE
Download when charging issue 104

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -9,6 +9,7 @@ wseemann
 hzulla
 andrewgaul
 peschmae0
+TomHennen
 
 Translations:
 

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -304,6 +304,13 @@
             </intent-filter>
         </receiver>
 
+        <receiver android:name=".receiver.PowerConnectionReceiver">
+            <intent-filter>
+                <action android:name="android.intent.action.ACTION_POWER_CONNECTED"/>
+                <action android:name="android.intent.action.ACTION_POWER_DISCONNECTED"/>
+            </intent-filter>
+        </receiver>
+
         <receiver android:name=".receiver.SPAReceiver">
             <intent-filter>
                 <action android:name="de.danoeh.antennapdsp.intent.SP_APPS_QUERY_FEEDS_RESPONSE"/>

--- a/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
+++ b/app/src/main/java/de/danoeh/antennapod/preferences/PreferenceController.java
@@ -195,6 +195,7 @@ public class PreferenceController {
                         if (newValue instanceof Boolean) {
                             ui.findPreference(UserPreferences.PREF_ENABLE_AUTODL_WIFI_FILTER).setEnabled((Boolean) newValue);
                             setSelectedNetworksEnabled((Boolean) newValue && UserPreferences.isEnableAutodownloadWifiFilter());
+                            ui.findPreference(UserPreferences.PREF_ENABLE_AUTODL_ON_BATTERY).setEnabled((Boolean) newValue);
                         }
                         return true;
                     }
@@ -376,6 +377,8 @@ public class PreferenceController {
         setSelectedNetworksEnabled(UserPreferences.isEnableAutodownload()
                 && UserPreferences.isEnableAutodownloadWifiFilter());
 
+        ui.findPreference(UserPreferences.PREF_ENABLE_AUTODL_ON_BATTERY)
+                .setEnabled(UserPreferences.isEnableAutodownload());
     }
 
     private void setEpisodeCacheSizeText(int cacheSize) {

--- a/app/src/main/java/de/danoeh/antennapod/receiver/PowerConnectionReceiver.java
+++ b/app/src/main/java/de/danoeh/antennapod/receiver/PowerConnectionReceiver.java
@@ -1,0 +1,45 @@
+package de.danoeh.antennapod.receiver;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.os.BatteryManager;
+import android.util.Log;
+
+import de.danoeh.antennapod.core.BuildConfig;
+import de.danoeh.antennapod.core.preferences.UserPreferences;
+import de.danoeh.antennapod.core.storage.DBTasks;
+import de.danoeh.antennapod.core.storage.DownloadRequester;
+
+// modified from http://developer.android.com/training/monitoring-device-state/battery-monitoring.html
+// and ConnectivityActionReceiver.java
+public class PowerConnectionReceiver extends BroadcastReceiver {
+	private static final String TAG = "PowerConnectionReceiver";
+
+	@Override
+    public void onReceive(Context context, Intent intent) {
+        int status = intent.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
+        boolean isCharging = status == BatteryManager.BATTERY_STATUS_CHARGING ||
+                status == BatteryManager.BATTERY_STATUS_FULL;
+
+        if (isCharging) {
+            Log.d(TAG, "charging, starting auto-download");
+            // we're plugged in, this is a great time to auto-download if everything else is
+            // right. So, even if the user allows auto-dl on battery, let's still start
+            // downloading now. They shouldn't mind.
+            // autodownloadUndownloadedItems will make sure we're on the right wifi networks,
+            // etc... so we don't have to worry about it.
+            DBTasks.autodownloadUndownloadedItems(context);
+        } else {
+            // if we're not supposed to be auto-downloading when we're not charging, stop it
+            if (!UserPreferences.isEnableAutodownloadOnBattery()) {
+                Log.d(TAG, "not charging anymore, canceling auto-download");
+                DownloadRequester.getInstance().cancelAllDownloads(context);
+            } else {
+                Log.d(TAG, "not charging anymore, but the user allows auto-download " +
+                           "when on battery so we'll keep going");
+            }
+        }
+
+    }
+}

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -93,6 +93,11 @@
                 android:title="@string/pref_automatic_download_title"
                 android:defaultValue="false"/>
             <CheckBoxPreference
+                android:key="prefEnableAutoDownloadOnBattery"
+                android:title="@string/pref_automatic_download_on_battery_title"
+                android:summary="@string/pref_automatic_download_on_battery_sum"
+                android:defaultValue="true"/>
+            <CheckBoxPreference
                 android:key="prefEnableAutoDownloadWifiFilter"
                 android:title="@string/pref_autodl_wifi_filter_title"
                 android:summary="@string/pref_autodl_wifi_filter_sum"/>

--- a/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/preferences/UserPreferences.java
@@ -51,6 +51,7 @@ public class UserPreferences implements
     public static final String PREF_DATA_FOLDER = "prefDataFolder";
     public static final String PREF_ENABLE_AUTODL = "prefEnableAutoDl";
     public static final String PREF_ENABLE_AUTODL_WIFI_FILTER = "prefEnableAutoDownloadWifiFilter";
+    public static final String PREF_ENABLE_AUTODL_ON_BATTERY = "prefEnableAutoDownloadOnBattery";
     private static final String PREF_AUTODL_SELECTED_NETWORKS = "prefAutodownloadSelectedNetworks";
     public static final String PREF_EPISODE_CACHE_SIZE = "prefEpisodeCacheSize";
     private static final String PREF_PLAYBACK_SPEED = "prefPlaybackSpeed";
@@ -82,6 +83,7 @@ public class UserPreferences implements
     private int theme;
     private boolean enableAutodownload;
     private boolean enableAutodownloadWifiFilter;
+    private boolean enableAutodownloadOnBattery;
     private String[] autodownloadSelectedNetworks;
     private int episodeCacheSize;
     private String playbackSpeed;
@@ -144,6 +146,7 @@ public class UserPreferences implements
         episodeCacheSize = readEpisodeCacheSizeInternal(sp.getString(
                 PREF_EPISODE_CACHE_SIZE, "20"));
         enableAutodownload = sp.getBoolean(PREF_ENABLE_AUTODL, false);
+        enableAutodownloadOnBattery = sp.getBoolean(PREF_ENABLE_AUTODL_ON_BATTERY, true);
         playbackSpeed = sp.getString(PREF_PLAYBACK_SPEED, "1.0");
         playbackSpeedArray = readPlaybackSpeedArray(sp.getString(
                 PREF_PLAYBACK_SPEED_ARRAY, null));
@@ -344,6 +347,11 @@ public class UserPreferences implements
         return instance.enableAutodownload;
     }
 
+    public static boolean isEnableAutodownloadOnBattery() {
+        instanceAvailable();
+        return instance.enableAutodownloadOnBattery;
+    }
+
     public static boolean shouldPauseForFocusLoss() {
         instanceAvailable();
         return instance.pauseForFocusLoss;
@@ -395,6 +403,8 @@ public class UserPreferences implements
                     PREF_EPISODE_CACHE_SIZE, "20"));
         } else if (key.equals(PREF_ENABLE_AUTODL)) {
             enableAutodownload = sp.getBoolean(PREF_ENABLE_AUTODL, false);
+        } else if (key.equals(PREF_ENABLE_AUTODL_ON_BATTERY)) {
+            enableAutodownloadOnBattery = sp.getBoolean(PREF_ENABLE_AUTODL_ON_BATTERY, true);
         } else if (key.equals(PREF_PLAYBACK_SPEED)) {
             playbackSpeed = sp.getString(PREF_PLAYBACK_SPEED, "1.0");
         } else if (key.equals(PREF_PLAYBACK_SPEED_ARRAY)) {

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -36,6 +36,7 @@ import de.danoeh.antennapod.core.service.download.DownloadStatus;
 import de.danoeh.antennapod.core.service.playback.PlaybackService;
 import de.danoeh.antennapod.core.util.DownloadError;
 import de.danoeh.antennapod.core.util.NetworkUtils;
+import de.danoeh.antennapod.core.util.PowerUtils;
 import de.danoeh.antennapod.core.util.QueueAccess;
 import de.danoeh.antennapod.core.util.comparator.FeedItemPubdateComparator;
 import de.danoeh.antennapod.core.util.exception.MediaFileNotFoundException;
@@ -449,7 +450,8 @@ public final class DBTasks {
     /**
      * Looks for undownloaded episodes in the queue or list of unread items and request a download if
      * 1. Network is available
-     * 2. There is free space in the episode cache
+     * 2. The device is charging or the user allows auto download on battery
+     * 3. There is free space in the episode cache
      * This method is executed on an internal single thread executor.
      *
      * @param context  Used for accessing the DB.
@@ -463,8 +465,10 @@ public final class DBTasks {
             public void run() {
                 if (BuildConfig.DEBUG)
                     Log.d(TAG, "Performing auto-dl of undownloaded episodes");
-                if (NetworkUtils.autodownloadNetworkAvailable(context)
-                        && UserPreferences.isEnableAutodownload()) {
+                if ((NetworkUtils.autodownloadNetworkAvailable(context)
+                        && UserPreferences.isEnableAutodownload())
+                     && (PowerUtils.deviceCharging(context)
+                        || UserPreferences.isEnableAutodownloadOnBattery())) {
                     final List<FeedItem> queue = DBReader.getQueue(context);
                     final List<FeedItem> unreadItems = DBReader
                             .getUnreadItemsList(context);

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DBTasks.java
@@ -463,12 +463,20 @@ public final class DBTasks {
         return autodownloadExec.submit(new Runnable() {
             @Override
             public void run() {
-                if (BuildConfig.DEBUG)
+
+                // true if we should auto download based on network status
+                boolean networkShouldAutoDl = NetworkUtils.autodownloadNetworkAvailable(context)
+                        && UserPreferences.isEnableAutodownload();
+
+                // true if we should auto download based on power status
+                boolean powerShouldAutoDl = PowerUtils.deviceCharging(context)
+                        || UserPreferences.isEnableAutodownloadOnBattery();
+
+                // we should only auto download if both network AND power are happy
+                if (networkShouldAutoDl && powerShouldAutoDl) {
+
                     Log.d(TAG, "Performing auto-dl of undownloaded episodes");
-                if ((NetworkUtils.autodownloadNetworkAvailable(context)
-                        && UserPreferences.isEnableAutodownload())
-                     && (PowerUtils.deviceCharging(context)
-                        || UserPreferences.isEnableAutodownloadOnBattery())) {
+
                     final List<FeedItem> queue = DBReader.getQueue(context);
                     final List<FeedItem> unreadItems = DBReader
                             .getUnreadItemsList(context);

--- a/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadRequester.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/storage/DownloadRequester.java
@@ -255,8 +255,7 @@ public class DownloadRequester {
      * Cancels all running downloads
      */
     public synchronized void cancelAllDownloads(Context context) {
-        if (BuildConfig.DEBUG)
-            Log.d(TAG, "Cancelling all running downloads");
+        Log.d(TAG, "Cancelling all running downloads");
         context.sendBroadcast(new Intent(
                 DownloadService.ACTION_CANCEL_ALL_DOWNLOADS));
     }

--- a/core/src/main/java/de/danoeh/antennapod/core/util/PowerUtils.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/util/PowerUtils.java
@@ -1,0 +1,32 @@
+package de.danoeh.antennapod.core.util;
+
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.BatteryManager;
+
+/**
+ * Created by Tom on 1/5/15.
+ */
+public class PowerUtils {
+
+    private static final String TAG = "PowerUtils";
+
+    private PowerUtils() {
+
+    }
+
+    /**
+     * @return true if the device is charging
+     */
+    public static boolean deviceCharging(Context context) {
+        // from http://developer.android.com/training/monitoring-device-state/battery-monitoring.html
+        IntentFilter iFilter = new IntentFilter(Intent.ACTION_BATTERY_CHANGED);
+        Intent batteryStatus = context.registerReceiver(null, iFilter);
+
+        int status = batteryStatus.getIntExtra(BatteryManager.EXTRA_STATUS, -1);
+        return (status == BatteryManager.BATTERY_STATUS_CHARGING ||
+                status == BatteryManager.BATTERY_STATUS_FULL);
+
+    }
+}

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -235,6 +235,8 @@
     <string name="pref_automatic_download_sum">Configure the automatic download of episodes.</string>
     <string name="pref_autodl_wifi_filter_title">Enable Wi-Fi filter</string>
     <string name="pref_autodl_wifi_filter_sum">Allow automatic download only for selected Wi-Fi networks.</string>
+    <string name="pref_automatic_download_on_battery_title">Automatic download on battery</string>
+    <string name="pref_automatic_download_on_battery_sum">Allow automatic download while on battery</string>
     <string name="pref_episode_cache_title">Episode cache</string>
     <string name="pref_theme_title_light">Light</string>
     <string name="pref_theme_title_dark">Dark</string>


### PR DESCRIPTION
Resolves issue #104. The user now has the option of disabling auto-download when the device is running on battery. Like wifi-connected auto-dl, a change in charging status will either trigger auto-dl (if other conditions are met) or cancel auto-dl (if the device is no longer charging).

I tested this on my HTC One M7 running 4.4.3.

I added myself to CONTRIBUTORS (I submitted a couple of other patches previously). I hope that's OK, if not feel free to remove it.

Please let me know if any updates are needed.