### PR TITLE
minor update to make the queue the first view. Not dynamic (always goes ...

### DIFF
--- a/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
+++ b/app/src/main/java/de/danoeh/antennapod/activity/MainActivity.java
@@ -144,7 +144,7 @@ public class MainActivity extends ActionBarActivity implements NavDrawerActivity
         if (mainFragment != null) {
             transaction.replace(R.id.main_view, mainFragment);
         } else {
-            loadFragment(NavListAdapter.VIEW_TYPE_NAV, POS_NEW, null);
+            loadFragment(NavListAdapter.VIEW_TYPE_NAV, POS_QUEUE, null);
         }
 
         externalPlayerFragment = new ExternalPlayerFragment();


### PR DESCRIPTION
A minor change that makes the queue the first view. Doesn't try to change behavior based on number of items in queue, because that information isn't available during onCreate() when we need to decide which fragment gets loaded. (navDrawerData gets filled in during loadData(), which happens in onResume() and for other events, but isn't there for onCreate()).

I'd entertain suggestions for how to handle this better...

