### PR TITLE
Auto delete episode update

### DIFF
--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -35,6 +35,12 @@
             android:key="prefFollowQueue"
             android:summary="@string/pref_followQueue_sum"
             android:title="@string/pref_followQueue_title"/>
+        <CheckBoxPreference
+            android:defaultValue="false"
+            android:enabled="true"
+            android:key="prefAutoDelete"
+            android:summary="Delete epidsode when playback completes"
+            android:title="Delete On Finish"/>
         <Preference
             android:key="prefPlaybackSpeedLauncher"
             android:summary="@string/pref_playback_speed_sum"

--- a/app/src/main/res/xml/preferences.xml
+++ b/app/src/main/res/xml/preferences.xml
@@ -39,13 +39,13 @@
             android:defaultValue="false"
             android:enabled="true"
             android:key="prefAutoDelete"
-            android:summary="Delete epidsode when playback completes"
-            android:title="Delete On Finish"/>
+            android:summary="@string/pref_auto_delete_sum"
+            android:title="@string/pref_auto_delete_title"/>
         <Preference
             android:key="prefPlaybackSpeedLauncher"
             android:summary="@string/pref_playback_speed_sum"
             android:title="@string/pref_playback_speed_title" />
-        
+
         <CheckBoxPreference
             android:defaultValue="false"
             android:enabled="true"

--- a/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
+++ b/core/src/main/java/de/danoeh/antennapod/core/service/playback/PlaybackService.java
@@ -539,6 +539,15 @@ public class PlaybackService extends Service {
             if (isAutoFlattrable(media) && UserPreferences.getAutoFlattrPlayedDurationThreshold() == 1.0f) {
                 DBTasks.flattrItemIfLoggedIn(PlaybackService.this, item);
             }
+
+            //Delete episode if enabled
+            if(UserPreferences.isAutoDelete()) {
+                DBWriter.deleteFeedMediaOfItem(PlaybackService.this, item.getMedia().getId());
+
+                if(BuildConfig.DEBUG)
+                    Log.d(TAG, "Episode Deleted");
+            }
+
         }
 
         // Load next episode if previous episode was in the queue and if there

--- a/core/src/main/res/values/strings.xml
+++ b/core/src/main/res/values/strings.xml
@@ -206,6 +206,8 @@
     <string name="flattr_label">Flattr</string>
     <string name="pref_pauseOnHeadsetDisconnect_sum">Pause playback when the headphones are disconnected</string>
     <string name="pref_followQueue_sum">Jump to next queue item when playback completes</string>
+    <string name="pref_auto_delete_sum">Delete episode when playback completes</string>
+    <string name="pref_auto_delete_title">Auto Delete</string>
     <string name="playback_pref">Playback</string>
     <string name="network_pref">Network</string>
     <string name="pref_autoUpdateIntervall_title">Update interval</string>


### PR DESCRIPTION
Pull #498 appears to have been abandoned, but it's something I wanted done, so I moved the title and summary into translatable strings.

There was also a suggestion of moving this to a feed-specific setting, but I think it's more useful as a global setting personally, so I left it as is. It could perhapse be overridden on the feed level later.