### PR TITLE
Use design time attributes to assist layouting and value preview.

### DIFF
--- a/app/src/main/res/layout-v14/directory_chooser.xml
+++ b/app/src/main/res/layout-v14/directory_chooser.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="match_parent" >
+    android:layout_height="match_parent"
+    tools:background="@android:color/darker_gray">
 
     <RelativeLayout
         android:id="@+id/footer"
@@ -62,7 +64,9 @@
             android:layout_alignParentLeft="true"
             android:layout_alignParentTop="true"
             android:background="?attr/selectableItemBackground"
-            android:src="?attr/navigation_up" />
+            android:src="?attr/navigation_up"
+            tools:src="@drawable/navigation_up"
+            tools:background="@android:color/holo_green_dark" />
 
         <TextView
             android:id="@+id/txtvSelectedFolderLabel"
@@ -74,7 +78,8 @@
             android:layout_marginTop="8dp"
             android:layout_toRightOf="@id/butNavUp"
             android:text="@string/selected_folder_label"
-            android:textStyle="bold" >
+            android:textStyle="bold"
+            tools:background="@android:color/holo_green_dark">
         </TextView>
 
         <TextView
@@ -87,7 +92,9 @@
             android:layout_toRightOf="@id/butNavUp"
             android:ellipsize="start"
             android:scrollHorizontally="true"
-            android:singleLine="true" />
+            android:singleLine="true"
+            tools:text="/path/to/selected/folder"
+            tools:background="@android:color/holo_green_dark"/>
 
         <View
             android:id="@+id/divider"

--- a/app/src/main/res/layout/audioplayer_activity.xml
+++ b/app/src/main/res/layout/audioplayer_activity.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
-    android:layout_height="match_parent">
+    android:layout_height="match_parent"
+    tools:background="@android:color/holo_red_dark">
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -14,7 +16,8 @@
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
             android:background="?attr/colorPrimary"
-            android:minHeight="?attr/actionBarSize">
+            android:minHeight="?attr/actionBarSize"
+            tools:background="@android:color/darker_gray">
 
             <LinearLayout
                 android:layout_width="match_parent"
@@ -34,7 +37,9 @@
                     android:gravity="left"
                     android:maxLines="2"
                     android:textColor="?android:attr/textColorPrimary"
-                    android:textSize="16sp" />
+                    android:textSize="16sp"
+                    tools:text="Audio title"
+                    tools:background="@android:color/holo_green_dark" />
 
                 <ImageButton
                     android:id="@+id/butCover"
@@ -44,7 +49,9 @@
                     android:layout_marginLeft="8dp"
                     android:background="?attr/selectableItemBackground"
                     android:contentDescription="@string/show_cover_label"
-                    android:gravity="right" />
+                    android:gravity="right"
+                    tools:src="@drawable/ic_stat_antenna_default"
+                    tools:background="@android:color/holo_green_dark" />
 
 
             </LinearLayout>
@@ -63,7 +70,8 @@
                 android:layout_width="match_parent"
                 android:layout_height="@dimen/audioplayer_playercontrols_length"
                 android:layout_alignParentBottom="true"
-                android:background="?attr/overlay_background">
+                android:background="?attr/overlay_background"
+                tools:background="@android:color/holo_purple">
 
                 <ImageButton
                     android:id="@+id/butPlay"
@@ -72,7 +80,9 @@
                     android:layout_centerHorizontal="true"
                     android:background="?attr/selectableItemBackground"
                     android:contentDescription="@string/pause_label"
-                    android:src="?attr/av_pause" />
+                    android:src="?attr/av_pause"
+                    tools:src="@drawable/ic_pause_white_36dp"
+                    tools:background="@android:color/holo_green_dark" />
 
                 <ImageButton
                     android:id="@+id/butRev"
@@ -81,7 +91,9 @@
                     android:layout_toLeftOf="@id/butPlay"
                     android:background="?attr/selectableItemBackground"
                     android:contentDescription="@string/rewind_label"
-                    android:src="?attr/av_rew_big" />
+                    android:src="?attr/av_rew_big"
+                    tools:src="@drawable/ic_fast_rewind_white_36dp"
+                    tools:background="@android:color/holo_blue_dark" />
 
                 <ImageButton
                     android:id="@+id/butFF"
@@ -90,7 +102,9 @@
                     android:layout_toRightOf="@id/butPlay"
                     android:background="?attr/selectableItemBackground"
                     android:contentDescription="@string/fast_forward_label"
-                    android:src="?attr/av_ff_big" />
+                    android:src="?attr/av_ff_big"
+                    tools:src="@drawable/ic_fast_forward_white_36dp"
+                    tools:background="@android:color/holo_blue_dark" />
 
                 <Button
                     android:id="@+id/butPlaybackSpeed"
@@ -102,7 +116,8 @@
                     android:src="?attr/av_fast_forward"
                     android:textColor="@color/gray"
                     android:textSize="@dimen/text_size_medium"
-                    android:visibility="gone" />
+                    android:visibility="gone"
+                    tools:background="@android:color/holo_green_dark" />
 
                 <ImageButton
                     android:id="@+id/butNavChaptersShownotes"
@@ -110,7 +125,9 @@
                     android:layout_height="match_parent"
                     android:layout_toLeftOf="@id/butRev"
                     android:background="?attr/selectableItemBackground"
-                    android:scaleType="centerInside" />
+                    android:scaleType="centerInside"
+                    android:src="@drawable/ic_toc_white_36dp"
+                    tools:background="@android:color/holo_green_dark" />
             </RelativeLayout>
 
             <RelativeLayout
@@ -131,7 +148,8 @@
                     android:layout_marginTop="16dp"
                     android:text="@string/position_default_label"
                     android:textColor="?android:attr/textColorSecondary"
-                    android:textSize="@dimen/text_size_micro" />
+                    android:textSize="@dimen/text_size_micro"
+                    tools:background="@android:color/holo_green_dark" />
 
                 <TextView
                     android:id="@+id/txtvLength"
@@ -144,7 +162,8 @@
                     android:layout_marginTop="16dp"
                     android:text="@string/position_default_label"
                     android:textColor="?android:attr/textColorSecondary"
-                    android:textSize="@dimen/text_size_micro" />
+                    android:textSize="@dimen/text_size_micro"
+                    tools:background="@android:color/holo_green_dark" />
 
                 <SeekBar
                     android:id="@+id/sbPosition"
@@ -156,7 +175,8 @@
                     android:layout_marginTop="16dp"
                     android:layout_toLeftOf="@id/txtvLength"
                     android:layout_toRightOf="@id/txtvPosition"
-                    android:max="500" />
+                    android:max="500"
+                    tools:background="@android:color/holo_green_dark" />
             </RelativeLayout>
 
             <FrameLayout
@@ -165,7 +185,8 @@
                 android:layout_height="0px"
                 android:layout_above="@id/playtime_layout"
                 android:layout_alignParentTop="true"
-                android:foreground="?android:windowContentOverlay" />
+                android:foreground="?android:windowContentOverlay"
+                tools:background="@android:color/holo_orange_light" />
 
         </RelativeLayout>
 

--- a/app/src/main/res/layout/cover_fragment.xml
+++ b/app/src/main/res/layout/cover_fragment.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/cover_fragment_root"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -12,6 +13,7 @@
         android:layout_height="match_parent"
         android:layout_gravity="center"
         android:adjustViewBounds="true"
-        android:scaleType="centerCrop" />
+        android:scaleType="centerCrop"
+        tools:src="@android:drawable/sym_def_app_icon" />
 
 </RelativeLayout>

--- a/app/src/main/res/layout/directory_chooser.xml
+++ b/app/src/main/res/layout/directory_chooser.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent" >
 
@@ -40,7 +41,9 @@
             android:layout_alignParentLeft="true"
             android:layout_alignParentTop="true"
             android:background="?attr/selectableItemBackground"
-            android:src="?attr/navigation_up" />
+            android:src="?attr/navigation_up"
+            tools:src="@drawable/navigation_up"
+            tools:background="@android:color/holo_green_dark" />
 
         <TextView
             android:id="@+id/txtvSelectedFolderLabel"
@@ -52,7 +55,8 @@
             android:layout_marginTop="8dp"
             android:layout_toRightOf="@id/butNavUp"
             android:text="@string/selected_folder_label"
-            android:textStyle="bold" >
+            android:textStyle="bold"
+            tools:background="@android:color/holo_blue_bright">
         </TextView>
 
         <TextView
@@ -65,7 +69,9 @@
             android:layout_toRightOf="@id/butNavUp"
             android:ellipsize="start"
             android:scrollHorizontally="true"
-            android:singleLine="true" />
+            android:singleLine="true"
+            tools:text="/path/to/selected/folder"
+            tools:background="@android:color/holo_blue_bright"/>
 
         <View
             android:id="@+id/divider"

--- a/app/src/main/res/layout/downloaded_episodeslist_item.xml
+++ b/app/src/main/res/layout/downloaded_episodeslist_item.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/listitem_threeline_height"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    tools:background="@android:color/darker_gray">
 
     <ImageView
         android:id="@+id/imgvImage"
@@ -14,7 +16,9 @@
         android:layout_marginLeft="@dimen/listitem_threeline_horizontalpadding"
         android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
         android:contentDescription="@string/cover_label"
-        android:scaleType="centerCrop" />
+        android:scaleType="centerCrop"
+        tools:src="@drawable/ic_stat_antenna_default"
+        tools:background="@android:color/holo_green_dark" />
 
     <RelativeLayout
         android:layout_width="0dp"
@@ -22,7 +26,8 @@
         android:layout_marginLeft="@dimen/listitem_threeline_textleftpadding"
         android:layout_marginRight="@dimen/listitem_threeline_textrightpadding"
         android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
-        android:layout_weight="1">
+        android:layout_weight="1"
+        tools:background="@android:color/holo_red_dark">
 
         <TextView
             android:id="@+id/txtvTitle"
@@ -33,7 +38,9 @@
             android:layout_alignParentRight="true"
             android:layout_alignParentTop="true"
             android:layout_centerVertical="true"
-            android:layout_marginBottom="4dp" />
+            android:layout_marginBottom="4dp"
+            tools:text="Downloaded episode title"
+            tools:background="@android:color/holo_green_dark" />
 
         <TextView
             android:id="@+id/txtvSize"
@@ -41,7 +48,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
-            android:layout_below="@id/txtvTitle" />
+            android:layout_below="@id/txtvTitle"
+            tools:text="23 MB"
+            tools:background="@android:color/holo_green_dark" />
 
         <TextView
             android:id="@+id/txtvPublished"
@@ -49,7 +58,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:layout_below="@id/txtvTitle" />
+            android:layout_below="@id/txtvTitle"
+            tools:text="Jan 23"
+            tools:background="@android:color/holo_green_dark" />
 
     </RelativeLayout>
 
@@ -64,6 +75,8 @@
         android:contentDescription="@string/remove_episode_lable"
         android:focusable="false"
         android:focusableInTouchMode="false"
-        android:src="?attr/content_discard" />
+        android:src="?attr/content_discard"
+        tools:src="@drawable/ic_delete_white_24dp"
+        tools:background="@android:color/holo_green_dark" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/downloadlist_item.xml
+++ b/app/src/main/res/layout/downloadlist_item.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/listitem_threeline_height"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    tools:background="@android:color/darker_gray">
 
     <LinearLayout
         android:layout_width="0dp"
@@ -19,7 +21,9 @@
             android:ellipsize="end"
             android:lines="1"
             android:textColor="?android:attr/textColorPrimary"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            tools:text="Download item title"
+            tools:background="@android:color/holo_green_dark" />
 
         <ProgressBar
             android:id="@+id/progProgress"
@@ -29,7 +33,8 @@
             android:layout_marginBottom="4dp"
             android:layout_marginLeft="@dimen/listitem_threeline_horizontalpadding"
             android:layout_marginRight="@dimen/listitem_threeline_horizontalpadding"
-            android:layout_marginTop="4dp" />
+            android:layout_marginTop="4dp"
+            tools:background="@android:color/holo_blue_light" />
 
         <RelativeLayout
             android:layout_width="match_parent"
@@ -46,7 +51,9 @@
                 android:ellipsize="end"
                 android:lines="1"
                 android:textColor="?android:attr/textColorPrimary"
-                android:textSize="@dimen/text_size_small" />
+                android:textSize="@dimen/text_size_small"
+                tools:text="21 MB / 42 MB"
+                tools:background="@android:color/holo_green_dark" />
 
             <TextView
                 android:id="@+id/txtvPercent"
@@ -56,7 +63,9 @@
                 android:ellipsize="end"
                 android:lines="1"
                 android:textColor="?android:attr/textColorPrimary"
-                android:textSize="@dimen/text_size_small" />
+                android:textSize="@dimen/text_size_small"
+                tools:text="50%"
+                tools:background="@android:color/holo_green_dark" />
         </RelativeLayout>
 
     </LinearLayout>
@@ -72,5 +81,7 @@
         android:contentDescription="@string/cancel_download_label"
         android:focusable="false"
         android:focusableInTouchMode="false"
-        android:src="?attr/navigation_cancel" />
+        android:src="?attr/navigation_cancel"
+        tools:src="@drawable/ic_cancel_white_24dp"
+        tools:background="@android:color/holo_green_dark" />
 </LinearLayout>

--- a/app/src/main/res/layout/downloadlog_item.xml
+++ b/app/src/main/res/layout/downloadlog_item.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    tools:background="@android:color/darker_gray">
 
     <RelativeLayout
         android:layout_width="match_parent"
@@ -17,7 +19,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
-            android:layout_marginLeft="@dimen/listitem_threeline_textleftpadding" />
+            android:layout_marginLeft="@dimen/listitem_threeline_textleftpadding"
+            tools:text="Media file"
+            tools:background="@android:color/holo_green_dark" />
 
         <TextView
             android:id="@+id/txtvTitle"
@@ -26,7 +30,9 @@
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:layout_alignParentTop="true"
-            android:layout_toLeftOf="@id/txtvType" />
+            android:layout_toLeftOf="@id/txtvType"
+            tools:text="Download item title"
+            tools:background="@android:color/holo_blue_light" />
     </RelativeLayout>
 
     <RelativeLayout
@@ -42,14 +48,18 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
-            android:layout_marginRight="8dp" />
+            android:layout_marginRight="8dp"
+            tools:text="January 23"
+            tools:background="@android:color/holo_green_dark" />
 
         <TextView
             android:id="@+id/txtvStatus"
             style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:layout_alignParentRight="true" />
+            android:layout_alignParentRight="true"
+            tools:text="successful"
+            tools:background="@android:color/holo_green_dark" />
 
     </RelativeLayout>
 
@@ -61,6 +71,8 @@
         android:layout_marginLeft="@dimen/listitem_threeline_horizontalpadding"
         android:layout_marginRight="@dimen/listitem_threeline_horizontalpadding"
         android:textColor="?android:attr/textColorTertiary"
-        android:textSize="@dimen/text_size_micro" />
+        android:textSize="@dimen/text_size_micro"
+        tools:text="@string/design_time_downloaded_log_failure_reason"
+        tools:background="@android:color/holo_green_dark" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/ellipsize_start_listitem.xml
+++ b/app/src/main/res/layout/ellipsize_start_listitem.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
               android:orientation="vertical"
               android:layout_width="match_parent"
-              android:layout_height="match_parent">
+              android:layout_height="match_parent"
+              tools:background="@android:color/darker_gray">
 
     <TextView
         android:id="@+id/txtvTitle"
@@ -14,6 +16,8 @@
         android:lines="1"
         android:singleLine="true"
         android:layout_margin="16dp"
-        android:ellipsize="start"/>
+        android:ellipsize="start"
+        tools:text="List item title"
+        tools:background="@android:color/holo_green_dark"/>
 
 </LinearLayout>

--- a/app/src/main/res/layout/external_player_fragment.xml
+++ b/app/src/main/res/layout/external_player_fragment.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
               android:id="@+id/fragmentLayout"
               android:layout_width="match_parent"
               android:layout_height="wrap_content"
               android:orientation="vertical"
               android:visibility="gone"
-              android:background="?attr/colorPrimary">
+              android:background="?attr/colorPrimary"
+              tools:visibility="visible"
+              tools:background="@android:color/darker_gray">
 
     <View
         android:layout_width="match_parent"
@@ -32,7 +35,9 @@
                 android:padding="4dp"
                 android:adjustViewBounds="true"
                 android:cropToPadding="true"
-                android:scaleType="fitXY"/>
+                android:scaleType="fitXY"
+                tools:src="@drawable/ic_stat_antenna_default"
+                tools:background="@android:color/holo_green_dark" />
 
             <TextView
                 android:id="@+id/txtvTitle"
@@ -46,7 +51,9 @@
                 android:ellipsize="end"
                 android:maxLines="2"
                 android:textSize="18sp"
-                android:fontFamily="sans-serif-light"/>
+                android:fontFamily="sans-serif-light"
+                tools:text="Playback item title"
+                tools:background="@android:color/holo_green_dark"/>
         </RelativeLayout>
 
         <ImageButton
@@ -54,7 +61,9 @@
             android:contentDescription="@string/pause_label"
             android:layout_width="@dimen/external_player_height"
             android:layout_height="@dimen/external_player_height"
-            android:background="?attr/selectableItemBackground"/>
+            android:background="?attr/selectableItemBackground"
+            tools:src="@drawable/ic_play_arrow_white_36dp"
+            tools:background="@android:color/holo_green_dark"/>
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/feedinfo.xml
+++ b/app/src/main/res/layout/feedinfo.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+              xmlns:tools="http://schemas.android.com/tools"
               android:layout_width="match_parent"
               android:layout_height="match_parent"
               android:orientation="vertical">
@@ -19,7 +20,9 @@
             android:layout_height="70dp"
             android:layout_alignParentLeft="true"
             android:layout_alignParentTop="true"
-            android:layout_margin="4dp"/>
+            android:layout_margin="4dp"
+            tools:src="@drawable/ic_stat_antenna_default"
+            tools:background="@android:color/holo_green_dark" />
 
         <TextView
             android:id="@+id/txtvTitle"
@@ -28,7 +31,9 @@
             android:layout_centerVertical="true"
             android:layout_margin="4dp"
             android:layout_toRightOf="@id/imgvCover"
-            style="@style/AntennaPod.TextView.Heading"/>
+            style="@style/AntennaPod.TextView.Heading"
+            tools:text="Feed title"
+            tools:background="@android:color/holo_green_dark" />
 
         <View
             android:id="@+id/divider"
@@ -67,7 +72,8 @@
                     android:layout_alignParentLeft="true"
                     android:layout_margin="8dp"
                     android:text="@string/author_label"
-                    android:textColor="?android:attr/textColorPrimary"/>
+                    android:textColor="?android:attr/textColorPrimary"
+                    tools:background="@android:color/holo_red_light" />
 
                 <TextView
                     android:id="@+id/txtvAuthor"
@@ -75,7 +81,9 @@
                     android:layout_height="wrap_content"
                     android:layout_alignParentRight="true"
                     android:layout_margin="8dp"
-                    android:layout_toRightOf="@id/center_divider"/>
+                    android:layout_toRightOf="@id/center_divider"
+                    tools:text="Daniel Oeh"
+                    tools:background="@android:color/holo_green_dark" />
 
                 <TextView
                     android:id="@+id/lblLanguage"
@@ -85,7 +93,8 @@
                     android:layout_below="@id/txtvAuthor"
                     android:layout_margin="8dp"
                     android:text="@string/language_label"
-                    android:textColor="?android:attr/textColorPrimary"/>
+                    android:textColor="?android:attr/textColorPrimary"
+                    tools:background="@android:color/holo_red_light" />
 
                 <TextView
                     android:id="@+id/txtvLanguage"
@@ -94,7 +103,9 @@
                     android:layout_alignParentRight="true"
                     android:layout_below="@id/txtvAuthor"
                     android:layout_margin="8dp"
-                    android:layout_toRightOf="@id/center_divider"/>
+                    android:layout_toRightOf="@id/center_divider"
+                    tools:text="English"
+                    tools:background="@android:color/holo_green_dark" />
             </RelativeLayout>
 
             <TextView
@@ -115,7 +126,8 @@
                 android:layout_margin="8dp"
                 android:text="@string/auto_download_label"
                 android:enabled="false"
-                android:textColor="?android:attr/textColorPrimary"/>
+                android:textColor="?android:attr/textColorPrimary"
+                tools:background="@android:color/holo_red_light" />
 
             <TextView
                 android:id="@+id/txtvAuthentication"
@@ -196,7 +208,9 @@
                 android:id="@+id/txtvDescription"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
-                android:layout_margin="8dp"/>
+                android:layout_margin="8dp"
+                android:text="@string/design_time_lorem_ipsum"
+                tools:background="@android:color/holo_green_dark" />
 
         </LinearLayout>
     </ScrollView>

--- a/app/src/main/res/layout/feeditem_fragment_header.xml
+++ b/app/src/main/res/layout/feeditem_fragment_header.xml
@@ -1,12 +1,14 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/header"
     android:layout_width="match_parent"
     android:layout_height="wrap_content"
     android:layout_gravity="center_horizontal"
     android:background="?attr/colorPrimary"
     android:gravity="center_horizontal"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    tools:background="@android:color/darker_gray">
 
 
     <RelativeLayout
@@ -24,7 +26,9 @@
             android:layout_marginBottom="8dp"
             android:layout_marginTop="16dp"
             android:contentDescription="@string/cover_label"
-            android:gravity="center_vertical" />
+            android:gravity="center_vertical"
+            tools:src="@drawable/ic_stat_antenna_default"
+            tools:background="@android:color/holo_green_dark" />
 
 
         <ImageButton
@@ -36,7 +40,9 @@
             android:background="?attr/selectableItemBackground"
             android:contentDescription="@string/butAction_label"
             android:paddingTop="4dp"
-            android:src="?attr/ic_action_overflow" />
+            android:src="?attr/ic_action_overflow"
+            tools:src="@drawable/ic_info_white_24dp"
+            tools:background="@android:color/holo_green_dark" />
 
         <TextView
             android:id="@+id/txtvTitle"
@@ -50,7 +56,9 @@
             android:layout_marginTop="16dp"
             android:layout_toLeftOf="@id/butMoreActions"
             android:layout_toRightOf="@id/imgvCover"
-            android:maxLines="5" />
+            android:maxLines="5"
+            tools:text="Podcast title"
+            tools:background="@android:color/holo_green_dark" />
     </RelativeLayout>
 
     <ProgressBar
@@ -67,7 +75,8 @@
         android:layout_width="match_parent"
         android:layout_height="?attr/actionBarSize"
         android:layout_marginRight="8dp"
-        android:orientation="horizontal">
+        android:orientation="horizontal"
+        tools:background="@android:color/holo_blue_bright">
 
         <Button
             android:id="@+id/butAction1"
@@ -80,7 +89,9 @@
             android:ellipsize="end"
             android:paddingTop="4dp"
             android:textColor="?android:attr/textColorPrimary"
-            android:textSize="@dimen/text_size_small" />
+            android:textSize="@dimen/text_size_small"
+            tools:text="Button 1"
+            tools:background="@android:color/holo_red_light" />
 
         <Button
             android:id="@+id/butAction2"
@@ -93,7 +104,9 @@
             android:ellipsize="end"
             android:paddingTop="4dp"
             android:textColor="?android:attr/textColorPrimary"
-            android:textSize="@dimen/text_size_small" />
+            android:textSize="@dimen/text_size_small"
+            tools:text="Button 2"
+            tools:background="@android:color/holo_orange_dark" />
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/feeditemlist_header.xml
+++ b/app/src/main/res/layout/feeditemlist_header.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/feeditemlist_header_height"
-    tools:context="de.danoeh.antennapod.activity.MainActivity">
+    tools:context="de.danoeh.antennapod.activity.MainActivity"
+    tools:background="@android:color/darker_gray">
 
     <ImageView
         android:id="@+id/imgvBackground"
@@ -22,7 +23,9 @@
         android:layout_marginBottom="16dp"
         android:layout_marginLeft="16dp"
         android:layout_marginTop="16dp"
-        android:contentDescription="@string/cover_label" />
+        android:contentDescription="@string/cover_label"
+        tools:src="@drawable/ic_stat_antenna_default"
+        tools:background="@android:color/holo_green_dark"/>
 
     <ImageButton
         android:id="@+id/butShowInfo"
@@ -35,7 +38,8 @@
         android:layout_marginTop="8dp"
         android:background="?attr/selectableItemBackground"
         android:contentDescription="@string/show_info_label"
-        android:src="@drawable/ic_info_white_24dp" />
+        android:src="@drawable/ic_info_white_24dp"
+        tools:background="@android:color/holo_green_dark"/>
 
     <TextView
         android:id="@+id/txtvTitle"
@@ -52,7 +56,9 @@
         android:maxLines="2"
         android:shadowColor="@color/black"
         android:shadowRadius="3"
-        android:textColor="@color/white" />
+        android:textColor="@color/white"
+        tools:text="Podcast title"
+        tools:background="@android:color/holo_green_dark" />
 
     <TextView
         android:id="@+id/txtvAuthor"
@@ -68,7 +74,9 @@
         android:shadowColor="@color/black"
         android:shadowRadius="3"
         android:textColor="@color/white"
-        android:textSize="@dimen/text_size_small" />
+        android:textSize="@dimen/text_size_small"
+        tools:text="Podcast author"
+        tools:background="@android:color/holo_green_dark" />
 
 
 </RelativeLayout>

--- a/app/src/main/res/layout/feeditemlist_item.xml
+++ b/app/src/main/res/layout/feeditemlist_item.xml
@@ -4,14 +4,16 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/listitem_threeline_height"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    tools:background="@android:color/darker_gray">
 
     <RelativeLayout
 
         android:layout_width="0dp"
         android:layout_height="match_parent"
         android:layout_marginLeft="@dimen/listitem_threeline_horizontalpadding"
-        android:layout_weight="1">
+        android:layout_weight="1"
+        tools:background="@android:color/holo_orange_dark">
 
         <TextView
             android:id="@+id/statusUnread"
@@ -20,7 +22,9 @@
             android:layout_height="wrap_content"
             android:layout_alignParentRight="true"
             android:layout_alignParentTop="true"
-            android:layout_margin="16dp" />
+            android:layout_margin="16dp"
+            tools:text="Status unread"
+            tools:background="@android:color/white" />
 
         <TextView
             android:id="@+id/txtvItemname"
@@ -31,7 +35,9 @@
             android:layout_alignParentTop="true"
             android:layout_marginBottom="8dp"
             android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
-            android:layout_toLeftOf="@id/statusUnread" />
+            android:layout_toLeftOf="@id/statusUnread"
+            tools:text="Feed item name"
+            tools:background="@android:color/holo_green_dark" />
 
 
         <ImageView
@@ -43,7 +49,9 @@
             android:layout_marginRight="4dp"
             android:contentDescription="@string/in_queue_label"
             android:src="?attr/stat_playlist"
-            android:visibility="visible" />
+            android:visibility="visible"
+            tools:src="@drawable/ic_list_white_24dp"
+            tools:background="@android:color/holo_red_light" />
 
         <ImageView
             android:id="@+id/imgvType"
@@ -52,7 +60,9 @@
             android:layout_below="@id/txtvItemname"
             android:layout_marginRight="4dp"
             android:layout_toLeftOf="@+id/imgvInPlaylist"
-            tools:ignore="ContentDescription" />
+            tools:ignore="ContentDescription"
+            tools:src="@drawable/ic_hearing_white_18dp"
+            tools:background="@android:color/holo_red_light" />
 
         <TextView
             android:id="@+id/txtvLenSize"
@@ -60,7 +70,9 @@
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
-            android:layout_below="@id/txtvItemname" />
+            android:layout_below="@id/txtvItemname"
+            tools:text="00:42:23"
+            tools:background="@android:color/holo_green_dark" />
 
         <ProgressBar
             android:id="@+id/pbar_episode_progress"
@@ -71,7 +83,8 @@
             android:layout_marginLeft="4dp"
             android:layout_marginRight="4dp"
             android:layout_toLeftOf="@id/imgvType"
-            android:layout_toRightOf="@id/txtvLenSize" />
+            android:layout_toRightOf="@id/txtvLenSize"
+            tools:background="@android:color/holo_blue_light" />
 
 
         <TextView
@@ -81,7 +94,9 @@
             android:layout_height="wrap_content"
             android:layout_below="@id/txtvItemname"
             android:layout_marginRight="4dp"
-            android:layout_toLeftOf="@id/imgvType" />
+            android:layout_toLeftOf="@id/imgvType"
+            tools:text="Jan 23"
+            tools:background="@android:color/holo_green_dark" />
     </RelativeLayout>
 
     <include layout="@layout/vertical_list_divider"/>

--- a/app/src/main/res/layout/gpodnet_podcast_list.xml
+++ b/app/src/main/res/layout/gpodnet_podcast_list.xml
@@ -35,7 +35,10 @@
         android:layout_margin="16dp"
         android:textAlignment="center"
         android:textSize="@dimen/text_size_small"
-        android:visibility="gone" />
+        android:visibility="gone"
+        tools:visibility="visible"
+        tools:text="Error message"
+        tools:background="@android:color/holo_red_light" />
 
     <Button
         android:id="@+id/butRetry"
@@ -45,5 +48,7 @@
         android:layout_centerHorizontal="true"
         android:layout_margin="16dp"
         android:text="@string/retry_label"
-        android:visibility="gone" />
+        android:visibility="gone"
+        tools:visibility="visible"
+        tools:background="@android:color/holo_red_light" />
 </RelativeLayout>

--- a/app/src/main/res/layout/gpodnet_podcast_listitem.xml
+++ b/app/src/main/res/layout/gpodnet_podcast_listitem.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+   xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="@dimen/listitem_threeline_height">
+    android:layout_height="@dimen/listitem_threeline_height"
+    tools:background="@android:color/darker_gray">
 
     <ImageView
         android:id="@+id/imgvCover"
@@ -17,7 +19,9 @@
         android:adjustViewBounds="true"
         android:contentDescription="@string/cover_label"
         android:cropToPadding="true"
-        android:scaleType="fitXY" />
+        android:scaleType="fitXY"
+        tools:src="@drawable/ic_stat_antenna_default"
+        tools:background="@android:color/holo_green_dark" />
 
     <TextView
         android:id="@+id/txtvTitle"
@@ -28,5 +32,7 @@
         android:layout_marginBottom="@dimen/listitem_threeline_verticalpadding"
         android:layout_marginRight="@dimen/listitem_threeline_horizontalpadding"
         android:layout_toRightOf="@id/imgvCover"
-        android:maxLines="1" />
+        android:maxLines="1"
+        tools:text="Podcast title"
+        tools:background="@android:color/holo_green_dark" />
 </RelativeLayout>

--- a/app/src/main/res/layout/gpodnetauth_credentials.xml
+++ b/app/src/main/res/layout/gpodnetauth_credentials.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
@@ -61,7 +62,9 @@
         android:maxLines="2"
         android:ellipsize="end"
         android:gravity="center"
-        android:layout_margin="16dp"/>
+        android:layout_margin="16dp"
+        tools:text="Error message"
+        tools:background="@android:color/holo_green_dark" />
 
     <ProgressBar
         android:id="@+id/progBarLogin"

--- a/app/src/main/res/layout/gpodnetauth_device.xml
+++ b/app/src/main/res/layout/gpodnetauth_device.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools"
                 android:layout_width="match_parent"
                 android:layout_height="match_parent">
 
@@ -70,7 +71,8 @@
         android:textColor="@color/download_failed_red"
         android:layout_margin="16dp"
         android:textSize="@dimen/text_size_small"
-        />
+        tools:text="Error message"
+        tools:background="@android:color/holo_green_dark" />
 
     <ProgressBar
         android:id="@+id/progbarCreateDevice"

--- a/app/src/main/res/layout/itemdescription_listitem.xml
+++ b/app/src/main/res/layout/itemdescription_listitem.xml
@@ -1,16 +1,20 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical">
+    android:orientation="vertical"
+    tools:background="@android:color/holo_orange_light">
 
     <TextView
         android:id="@+id/txtvTitle"
         style="@style/AntennaPod.TextView.ListItemPrimaryTitle"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="16dp" />
+        android:layout_margin="16dp"
+        tools:text="Feed item title"
+        tools:background="@android:color/holo_green_dark" />
 
     <TextView
         android:id="@+id/txtvDescription"
@@ -20,5 +24,7 @@
         android:layout_marginBottom="16dp"
         android:layout_marginLeft="16dp"
         android:layout_marginRight="16dp"
-        android:lines="3" />
+        android:lines="3"
+        tools:text="Feed item description"
+        tools:background="@android:color/holo_green_dark" />
 </LinearLayout>

--- a/app/src/main/res/layout/main.xml
+++ b/app/src/main/res/layout/main.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <android.support.v4.widget.DrawerLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/drawer_layout"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
@@ -14,7 +15,9 @@
             android:id="@+id/playerFragment"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_alignParentBottom="true" />
+            android:layout_alignParentBottom="true"
+            tools:layout_height="64dp"
+            tools:background="@android:color/holo_green_light" />
 
         <android.support.v7.widget.Toolbar
             android:id="@+id/toolbar"
@@ -22,14 +25,16 @@
             android:layout_height="wrap_content"
             android:layout_alignParentTop="true"
             android:background="?attr/colorPrimary"
-            android:minHeight="?attr/actionBarSize"/>
+            android:minHeight="?attr/actionBarSize"
+            tools:background="@android:color/holo_blue_dark" />
         <FrameLayout
             android:id="@+id/main_view"
             android:layout_width="match_parent"
             android:layout_height="0px"
             android:layout_above="@id/playerFragment"
             android:layout_below="@id/toolbar"
-            android:foreground="?android:windowContentOverlay" />
+            android:foreground="?android:windowContentOverlay"
+            tools:background="@android:color/holo_red_dark" />
 
     </RelativeLayout>
 

--- a/app/src/main/res/layout/nav_feedlistitem.xml
+++ b/app/src/main/res/layout/nav_feedlistitem.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools"
                 android:orientation="vertical"
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/listitem_iconwithtext_height">
+                android:layout_height="@dimen/listitem_iconwithtext_height"
+                tools:background="@android:color/darker_gray">
 
 
     <ImageView
@@ -18,7 +20,9 @@
         android:scaleType="fitXY"
         android:layout_marginTop="8dp"
         android:layout_marginBottom="8dp"
-        android:layout_marginLeft="@dimen/listitem_icon_leftpadding"/>
+        android:layout_marginLeft="@dimen/listitem_icon_leftpadding"
+        tools:src="@drawable/ic_stat_antenna_default"
+        tools:background="@android:color/holo_green_dark"/>
 
 
     <TextView
@@ -36,5 +40,7 @@
         android:layout_marginBottom="@dimen/listitem_iconwithtext_textverticalpadding"
         android:layout_marginRight="@dimen/listitem_icon_rightpadding"
         android:layout_toRightOf="@id/imgvCover"
+        tools:text="Navigation feed item title"
+        tools:background="@android:color/holo_green_dark"
         />
 </RelativeLayout>

--- a/app/src/main/res/layout/nav_list.xml
+++ b/app/src/main/res/layout/nav_list.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/nav_layout"
     android:layout_width="@dimen/drawer_width"
     android:layout_height="match_parent"
@@ -19,13 +20,16 @@
         android:dividerHeight="0dp"
         android:paddingBottom="@dimen/list_vertical_padding"
         android:paddingTop="@dimen/list_vertical_padding"
-        android:scrollbarStyle="outsideOverlay" />
+        android:scrollbarStyle="outsideOverlay"
+        tools:listitem="@layout/nav_listitem"
+        tools:background="@android:color/holo_purple" />
 
     <View
         android:layout_width="@dimen/drawer_width"
         android:layout_height="1dp"
         android:layout_centerVertical="true"
-        android:background="?android:attr/listDivider" />
+        android:background="?android:attr/listDivider"
+        tools:background="@android:color/holo_red_dark" />
 
     <LinearLayout
         android:id="@+id/nav_settings"
@@ -49,7 +53,9 @@
             android:cropToPadding="true"
             android:padding="8dp"
             android:scaleType="centerCrop"
-            android:src="?attr/ic_settings" />
+            android:src="?attr/ic_settings"
+            tools:src="@android:drawable/sym_def_app_icon"
+            tools:background="@android:color/holo_orange_dark" />
 
         <TextView
             android:layout_width="0dp"
@@ -60,7 +66,8 @@
             android:gravity="center_vertical"
             android:text="@string/settings_label"
             android:textColor="?android:attr/textColorPrimary"
-            android:textSize="@dimen/text_size_navdrawer" />
+            android:textSize="@dimen/text_size_navdrawer"
+            tools:background="@android:color/holo_green_light"/>
 
     </LinearLayout>
 

--- a/app/src/main/res/layout/nav_listitem.xml
+++ b/app/src/main/res/layout/nav_listitem.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+                xmlns:tools="http://schemas.android.com/tools"
                 android:orientation="vertical"
                 android:layout_width="match_parent"
-                android:layout_height="@dimen/listitem_iconwithtext_height">
+                android:layout_height="@dimen/listitem_iconwithtext_height"
+                tools:background="@android:color/darker_gray">
 
     <ImageView
         android:id="@+id/imgvCover"
@@ -18,7 +20,9 @@
         android:padding="8dp"
         android:layout_marginLeft="@dimen/listitem_icon_leftpadding"
         android:layout_marginTop="8dp"
-        android:layout_marginBottom="8dp"/>
+        android:layout_marginBottom="8dp"
+        tools:src="@drawable/ic_new_releases_white_24dp"
+        tools:background="@android:color/holo_green_dark"/>
 
 
     <TextView
@@ -36,6 +40,8 @@
         android:layout_marginBottom="@dimen/listitem_iconwithtext_textverticalpadding"
         android:layout_marginRight="48dp"
         android:layout_toRightOf="@id/imgvCover"
+        tools:text="Navigation item title"
+        tools:background="@android:color/holo_green_dark"
         />
 
     <TextView
@@ -50,5 +56,7 @@
         android:layout_marginBottom="14dp"
         android:layout_marginRight="@dimen/listitem_icon_rightpadding"
         android:layout_alignParentRight="true"
-        android:layout_centerVertical="true"/>
+        android:layout_centerVertical="true"
+        tools:text="23"
+        tools:background="@android:color/holo_green_dark"/>
 </RelativeLayout>

--- a/app/src/main/res/layout/nav_section_item.xml
+++ b/app/src/main/res/layout/nav_section_item.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="24dp"
     android:background="@android:color/transparent"
@@ -10,5 +11,6 @@
         android:layout_width="match_parent"
         android:layout_height="1dp"
         android:layout_centerVertical="true"
-        android:background="?android:attr/listDivider" />
+        android:background="?android:attr/listDivider"
+        tools:background="@android:color/holo_red_dark"/>
 </RelativeLayout>

--- a/app/src/main/res/layout/new_episodes_fragment.xml
+++ b/app/src/main/res/layout/new_episodes_fragment.xml
@@ -2,6 +2,7 @@
 
 <FrameLayout xmlns:android="http://schemas.android.com/apk/res/android"
              xmlns:dslv="http://schemas.android.com/apk/res-auto"
+             xmlns:tools="http://schemas.android.com/tools"
              android:orientation="vertical"
              android:layout_width="match_parent"
              android:layout_height="match_parent">
@@ -25,7 +26,8 @@
             dslv:sort_enabled="false"
             dslv:track_drag_sort="false"
             dslv:float_background_color="?attr/dragview_float_background"
-            dslv:use_default_controller="true"/>
+            dslv:use_default_controller="true"
+            tools:background="@android:color/holo_green_dark"/>
 
     <TextView
         android:id="@id/android:empty"
@@ -41,6 +43,10 @@
         android:layout_height="wrap_content"
         android:layout_gravity="center"
         android:indeterminateOnly="true"
-        android:visibility="gone"/>
+        android:visibility="gone"
+        tools:visibility="visible"
+        tools:layout_width="match_parent"
+        tools:layout_height="64dp"
+        tools:background="@android:color/holo_red_light"/>
 
 </FrameLayout>

--- a/app/src/main/res/layout/new_episodes_listitem.xml
+++ b/app/src/main/res/layout/new_episodes_listitem.xml
@@ -1,9 +1,11 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/listitem_threeline_height"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    tools:background="@android:color/darker_gray">
 
     <ImageView
         android:id="@+id/imgvImage"
@@ -14,7 +16,9 @@
         android:layout_marginLeft="@dimen/listitem_threeline_horizontalpadding"
         android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
         android:contentDescription="@string/cover_label"
-        android:scaleType="centerCrop" />
+        android:scaleType="centerCrop"
+        tools:src="@drawable/ic_stat_antenna_default"
+        tools:background="@android:color/holo_green_dark" />
 
     <RelativeLayout
         android:layout_width="0dp"
@@ -23,7 +27,8 @@
         android:layout_marginLeft="@dimen/listitem_threeline_textleftpadding"
         android:layout_marginRight="@dimen/listitem_threeline_textrightpadding"
         android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
-        android:layout_weight="1">
+        android:layout_weight="1"
+        tools:background="@android:color/white" >
 
 
         <TextView
@@ -41,7 +46,9 @@
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:layout_alignParentTop="true"
-            android:layout_toLeftOf="@id/statusUnread" />
+            android:layout_toLeftOf="@id/statusUnread"
+            tools:text="Episode title"
+            tools:background="@android:color/holo_green_dark" />
 
         <RelativeLayout
             android:id="@+id/bottom_bar"
@@ -50,7 +57,8 @@
             android:layout_alignParentBottom="true"
             android:layout_alignParentLeft="true"
             android:layout_alignParentRight="true"
-            android:layout_marginTop="16dp">
+            android:layout_marginTop="16dp"
+            tools:background="@android:color/holo_red_light" >
 
             <ImageView
                 android:id="@id/imgvInPlaylist"
@@ -60,7 +68,9 @@
                 android:layout_marginLeft="8dp"
                 android:layout_marginRight="4dp"
                 android:contentDescription="@string/in_queue_label"
-                android:src="?attr/stat_playlist" />
+                android:src="?attr/stat_playlist"
+                tools:src="@drawable/ic_list_grey600_24dp"
+                tools:background="@android:color/black" />
 
             <ProgressBar
                 android:id="@+id/pbar_download_progress"
@@ -78,7 +88,9 @@
                 android:layout_width="0dp"
                 android:layout_height="wrap_content"
                 android:layout_alignParentLeft="true"
-                android:layout_toLeftOf="@id/imgvInPlaylist" />
+                android:layout_toLeftOf="@id/imgvInPlaylist"
+                tools:text="00:42:23"
+                tools:background="@android:color/holo_blue_dark" />
 
             <TextView
                 android:id="@+id/txtvPublished"
@@ -87,7 +99,9 @@
                 android:layout_height="wrap_content"
                 android:layout_alignParentTop="true"
                 android:layout_toLeftOf="@id/imgvInPlaylist"
-                android:ellipsize="end" />
+                android:ellipsize="end"
+                tools:text="Jan 23"
+                tools:background="@android:color/holo_green_dark" />
 
         </RelativeLayout>
     </RelativeLayout>

--- a/app/src/main/res/layout/onlinefeedview_header.xml
+++ b/app/src/main/res/layout/onlinefeedview_header.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent">
 
@@ -13,7 +14,9 @@
         android:layout_marginLeft="16dp"
         android:layout_marginRight="16dp"
         android:layout_marginTop="16dp"
-        android:contentDescription="@string/cover_label" />
+        android:contentDescription="@string/cover_label"
+        tools:src="@drawable/ic_stat_antenna_default"
+        tools:background="@android:color/holo_green_dark" />
 
     <TextView
         android:id="@+id/txtvTitle"
@@ -27,7 +30,9 @@
         android:layout_toRightOf="@id/imgvCover"
         android:ellipsize="end"
         android:gravity="center_vertical"
-        android:maxLines="2" />
+        android:maxLines="2"
+        tools:text="Online feed title"
+        tools:background="@android:color/holo_green_dark" />
 
     <TextView
         android:id="@+id/txtvAuthor"
@@ -40,7 +45,9 @@
         android:ellipsize="end"
         android:lines="1"
         android:textColor="?android:attr/textColorSecondary"
-        android:textSize="@dimen/text_size_small" />
+        android:textSize="@dimen/text_size_small"
+        tools:text="Online feed author"
+        tools:background="@android:color/holo_green_dark" />
 
     <LinearLayout
         android:layout_width="match_parent"
@@ -75,7 +82,9 @@
             android:layout_marginLeft="16dp"
             android:layout_marginRight="16dp"
             android:textColor="?android:attr/textColorSecondary"
-            android:textSize="@dimen/text_size_small" />
+            android:textSize="@dimen/text_size_small"
+            tools:text="@string/design_time_lorem_ipsum"
+            tools:background="@android:color/holo_green_dark"/>
 
     </LinearLayout>
 </RelativeLayout>

--- a/app/src/main/res/layout/opml_import.xml
+++ b/app/src/main/res/layout/opml_import.xml
@@ -1,20 +1,25 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:orientation="vertical" >
+    android:orientation="vertical"
+    tools:background="@android:color/darker_gray">
 
     <TextView
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
         android:layout_margin="8dp"
-        android:text="@string/opml_import_explanation" />
+        android:text="@string/opml_import_explanation"
+        tools:background="@android:color/holo_green_dark" />
 
     <TextView
         android:id="@+id/txtvPath"
         android:layout_width="match_parent"
         android:layout_height="wrap_content"
-        android:layout_margin="8dp" />
+        android:layout_margin="8dp"
+        tools:text="Path"
+        tools:background="@android:color/holo_green_dark" />
 
     <Button
         android:id="@+id/butStartImport"

--- a/app/src/main/res/layout/queue_listitem.xml
+++ b/app/src/main/res/layout/queue_listitem.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/listitem_threeline_height"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    tools:background="@android:color/darker_gray" >
 
     <ImageView
         android:id="@+id/drag_handle"
@@ -13,7 +14,9 @@
         android:layout_margin="8dp"
         android:contentDescription="@string/drag_handle_content_description"
         android:scaleType="center"
-        android:src="?attr/dragview_background" />
+        android:src="?attr/dragview_background"
+        tools:src="@drawable/ic_drag_handle"
+        tools:background="@android:color/holo_green_dark" />
 
     <ImageView
         android:id="@+id/imgvImage"
@@ -23,7 +26,9 @@
         android:layout_marginBottom="@dimen/listitem_threeline_verticalpadding"
         android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
         android:contentDescription="@string/cover_label"
-        android:scaleType="centerCrop" />
+        android:scaleType="centerCrop"
+        tools:src="@drawable/ic_stat_antenna_default"
+        tools:background="@android:color/holo_green_dark"/>
 
     <RelativeLayout
         android:layout_width="0dp"
@@ -32,7 +37,8 @@
         android:layout_marginLeft="@dimen/listitem_threeline_textleftpadding"
         android:layout_marginRight="@dimen/listitem_threeline_textrightpadding"
         android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
-        android:layout_weight="1">
+        android:layout_weight="1"
+        tools:background="@android:color/holo_red_dark">
 
         <TextView
             android:id="@+id/txtvTitle"
@@ -41,7 +47,9 @@
             android:layout_height="wrap_content"
             android:layout_alignParentLeft="true"
             android:layout_alignParentRight="true"
-            android:layout_alignParentTop="true" />
+            android:layout_alignParentTop="true"
+            android:text="Queue item title"
+            tools:background="@android:color/holo_blue_light" />
 
         <RelativeLayout
             android:id="@+id/bottom_bar"
@@ -57,7 +65,9 @@
                 style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:layout_alignParentLeft="true" />
+                android:layout_alignParentLeft="true"
+                android:text="00:42:23"
+                tools:background="@android:color/holo_blue_light" />
 
             <ProgressBar
                 android:id="@+id/pbar_download_progress"
@@ -67,7 +77,8 @@
                 android:layout_alignParentRight="true"
                 android:layout_marginLeft="8dp"
                 android:layout_toRightOf="@id/txtvPosition"
-                android:max="100" />
+                android:max="100"
+                tools:background="@android:color/holo_blue_light" />
 
         </RelativeLayout>
     </RelativeLayout>

--- a/app/src/main/res/layout/searchlist_item.xml
+++ b/app/src/main/res/layout/searchlist_item.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    android:layout_width="match_parent"
-    android:layout_height="@dimen/listitem_threeline_height">
+                xmlns:tools="http://schemas.android.com/tools"
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/listitem_threeline_height"
+                tools:background="@android:color/darker_gray">
 
     <ImageView
         android:id="@+id/imgvFeedimage"
@@ -13,7 +15,9 @@
         android:layout_marginLeft="@dimen/listitem_threeline_horizontalpadding"
         android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
         android:contentDescription="@string/cover_label"
-        android:scaleType="centerCrop" />
+        android:scaleType="centerCrop"
+        tools:src="@drawable/ic_stat_antenna_default"
+        tools:background="@android:color/holo_green_dark"/>
 
     <LinearLayout
         android:layout_width="wrap_content"
@@ -22,21 +26,26 @@
         android:layout_marginRight="@dimen/listitem_threeline_verticalpadding"
         android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
         android:layout_toRightOf="@id/imgvFeedimage"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        tools:background="@android:color/holo_red_dark">
 
         <TextView
             android:id="@+id/txtvTitle"
             style="@style/AntennaPod.TextView.ListItemPrimaryTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:layout_marginBottom="8dp" />
+            android:layout_marginBottom="8dp"
+            tools:text="Search item title"
+            tools:background="@android:color/holo_green_dark" />
 
         <TextView
             android:id="@+id/txtvSubtitle"
             style="@style/AntennaPod.TextView.ListItemSecondaryTitle"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
-            android:lines="1" />
+            android:lines="1"
+            tools:text="Search item subtitle"
+            tools:background="@android:color/holo_blue_light"/>
     </LinearLayout>
 
 </RelativeLayout>

--- a/app/src/main/res/layout/secondary_action.xml
+++ b/app/src/main/res/layout/secondary_action.xml
@@ -8,4 +8,6 @@
     android:clickable="false"
     android:focusable="false"
     android:focusableInTouchMode="false"
-    tools:ignore="ContentDescription" />
+    tools:ignore="ContentDescription"
+    tools:src="@drawable/ic_play_arrow_grey600_36dp"
+    tools:background="@android:color/holo_green_dark" />

--- a/app/src/main/res/layout/simplechapter_item.xml
+++ b/app/src/main/res/layout/simplechapter_item.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="@dimen/listitem_threeline_height"
-    android:orientation="horizontal">
+    android:orientation="horizontal"
+    tools:background="@android:color/darker_gray">
 
     <TextView
         android:id="@+id/txtvStart"
@@ -11,7 +13,9 @@
         android:layout_height="match_parent"
         android:layout_gravity="center_vertical"
         android:layout_marginLeft="@dimen/listitem_threeline_horizontalpadding"
-        android:gravity="center_vertical" />
+        android:gravity="center_vertical"
+        tools:text="Start"
+        tools:background="@android:color/holo_green_dark" />
 
     <LinearLayout
         android:layout_width="0dp"
@@ -22,7 +26,8 @@
         android:layout_marginTop="@dimen/listitem_threeline_verticalpadding"
         android:layout_weight="1"
         android:gravity="center_vertical"
-        android:orientation="vertical">
+        android:orientation="vertical"
+        tools:background="@android:color/holo_red_dark">
 
         <TextView
             android:id="@+id/txtvTitle"
@@ -32,7 +37,9 @@
             android:ellipsize="end"
             android:maxLines="2"
             android:textColor="?android:attr/textColorPrimary"
-            android:textSize="16sp" />
+            android:textSize="16sp"
+            tools:text="Chapter title"
+            tools:background="@android:color/holo_green_dark" />
 
         <TextView
             android:id="@+id/txtvLink"
@@ -41,7 +48,10 @@
             android:focusable="false"
             android:focusableInTouchMode="false"
             android:maxLines="1"
-            android:visibility="gone" />
+            android:visibility="gone"
+            tools:visibility="visible"
+            tools:text="Link"
+            tools:background="@android:color/holo_green_dark" />
 
     </LinearLayout>
 
@@ -56,6 +66,8 @@
         android:contentDescription="@string/chapters_label"
         android:focusable="false"
         android:focusableInTouchMode="false"
-        android:src="?attr/av_play" />
+        android:src="?attr/av_play"
+        tools:src="@drawable/ic_play_arrow_white_36dp"
+        tools:background="@android:color/holo_green_dark" />
 
 </LinearLayout>

--- a/app/src/main/res/layout/time_dialog.xml
+++ b/app/src/main/res/layout/time_dialog.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical" >
@@ -42,13 +43,15 @@
             android:layout_width="0dp"
             android:layout_height="wrap_content"
             android:layout_marginRight="8dp"
-            android:layout_weight="1" />
+            android:layout_weight="1"
+            tools:text="Confirm" />
 
         <Button
             android:id="@+id/butCancel"
             android:layout_width="0dp"
             android:layout_height="wrap_content"
-            android:layout_weight="1" />
+            android:layout_weight="1"
+            tools:text="Cancel" />
     </LinearLayout>
 
 </LinearLayout>

--- a/app/src/main/res/layout/vertical_list_divider.xml
+++ b/app/src/main/res/layout/vertical_list_divider.xml
@@ -1,7 +1,9 @@
 <?xml version="1.0" encoding="utf-8"?>
 <View xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="1dp"
     android:layout_height="match_parent"
     android:layout_marginBottom="16dp"
     android:layout_marginTop="16dp"
-    android:background="?android:attr/listDivider"/>
+    android:background="?android:attr/listDivider"
+    tools:background="@android:color/holo_red_dark" />

--- a/app/src/main/res/values/design_time_attributes.xml
+++ b/app/src/main/res/values/design_time_attributes.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources
+        xmlns:tools="http://schemas.android.com/tools"
+        tools:ignore="MissingTranslation">
+
+    <!--
+    DESIGN TIME ATTRIBUTES
+    Put too long strings to embed in layout files here.
+    -->
+
+    <string name="design_time_lorem_ipsum">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Vivamus ullamcorper
+        tempor metus, at varius tellus dignissim et. Fusce quis justo sollicitudin,
+        feugiat mi in, accumsan erat. Fusce tempor, sapien ut luctus scelerisque,
+        lectus nisi hendrerit odio, eget mattis lorem massa id eros. Integer consequat
+        tellus eu rhoncus pellentesque. Quisque et leo faucibus, aliquam nisi ut,
+        feugiat lectus.
+    </string>
+    <string name="design_time_downloaded_log_failure_reason">
+        IO Error: failed to connect to feeds.example.com/100.100.100.100
+        (port 80) after 3000ms: isConnected failed: ECONNREFUSED (Connection refused)
+    </string>
+
+</resources>


### PR DESCRIPTION
I added [Design Time Attributes][dta] which are useful to **render meaningful previews** for the layout files in Android Studio. They also help to optimize layout in general. Further you can **add placeholders** for text and image elements. I use strong **background colors** for text fields and image views to preview their exact dimensions and margins.
None of these changes affects the compiled application code.

Here is an extreme example for *layout/downloadlog_item.xml*:

## Preview without Design Time Attributes

![antennapod-download-before](https://cloud.githubusercontent.com/assets/144518/5891052/fc2e8bea-a47e-11e4-9f2f-08688b52c671.png)

## Preview with Design Time Attributes

![antennapod-download-improved](https://cloud.githubusercontent.com/assets/144518/5891054/00dc547e-a47f-11e4-87f2-ef340384c2cc.png)




[dta]: http://tools.android.com/tips/layout-designtime-attributes